### PR TITLE
Controller Support

### DIFF
--- a/CSharpSourceCode/AbilitySystem/AbilityManagerMissionLogic.cs
+++ b/CSharpSourceCode/AbilitySystem/AbilityManagerMissionLogic.cs
@@ -55,6 +55,8 @@ namespace TOR_Core.AbilitySystem
         private bool _disableCombatActionsAfterCast;
         private float _elapsedTimeSinceLastActivation;
         private bool _wieldOffHandStaff;
+        private IInputContext _inputContext => Mission.InputManager; //Easy way to access gamekeys
+        
         public delegate void OnHideOutBossFightInit();
         public event OnHideOutBossFightInit OnInitHideOutBossFight;
 
@@ -66,6 +68,7 @@ namespace TOR_Core.AbilitySystem
         {
             base.OnBehaviorInitialize();
             Mission.OnItemPickUp += OnItemPickup;
+            
         }
 
         public void InitHideOutBossFight()
@@ -82,6 +85,7 @@ namespace TOR_Core.AbilitySystem
             _quickCastMenuKey = HotKeyManager.GetCategory(nameof(TORGameKeyContext)).GetGameKey("QuickCastSelectionMenu");
             _quickCast = HotKeyManager.GetCategory(nameof(TORGameKeyContext)).GetGameKey("QuickCast");
             _specialMoveKey = HotKeyManager.GetCategory(nameof(TORGameKeyContext)).GetGameKey("CareerAbilityCast");
+            _keyContext.GetGameKey(25).ControllerKey.ChangeKey(InputKey.Invalid); // Unbinding view Character Controller key from controller. 
         }
 
         public override void OnPreMissionTick(float dt)
@@ -381,7 +385,7 @@ namespace TOR_Core.AbilitySystem
                     break;
                 case AbilityModeState.Targeting:
                     {
-                        if (Input.IsKeyPressed(InputKey.LeftMouseButton))
+                        if (_inputContext.IsGameKeyPressed(9)) //Check's if attack gamekey is pressed (default left mouse for kb&m and Right Trigger for controller) 
                         {
                             bool flag = _abilityComponent.CurrentAbility.Crosshair == null ||
                                         !_abilityComponent.CurrentAbility.Crosshair.IsVisible ||
@@ -401,7 +405,7 @@ namespace TOR_Core.AbilitySystem
                                 }
                             }
                         }
-                        else if (Input.IsKeyPressed(_quickCastMenuKey.KeyboardKey.InputKey) || Input.IsKeyPressed(_quickCastMenuKey.ControllerKey.InputKey))
+                        else if (Input.IsKeyPressed(_quickCastMenuKey.KeyboardKey.InputKey) || Input.IsKeyPressed(_quickCastMenuKey.ControllerKey.InputKey)) //Could be checked with _inputContext.IsGameKeyPressed(109) for both the controller and keyboard but need testing since these gamekeys are introduced by the mod
                         {
                             EnableQuickSelectionMenuMode();
                         }

--- a/CSharpSourceCode/GameManagers/TORGameKeyContext.cs
+++ b/CSharpSourceCode/GameManagers/TORGameKeyContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TaleWorlds.Core;
 using TaleWorlds.DotNet;
 using TaleWorlds.InputSystem;
@@ -16,7 +16,7 @@ namespace TOR_Core.GameManagers
         public const int CareerAbilityCast = (int)TorKeyMap.CareerAbilityCast;
         public TORGameKeyContext() :  base(nameof(TORGameKeyContext),120) // I don't exactly know why they do it, but they seem to cast the id enums of "GameKey" to strings, and then read them out. So the first 108 positions are blocked since their names are predefined of the GameKey enum.
         {
-            RegisterGameKey(new GameKey(QuickCastSelectionMenu, "QuickCastSelectionMenu", nameof(TORGameKeyContext), InputKey.Q, nameof(TORGameKeyContext)));
+            RegisterGameKey(new GameKey(QuickCastSelectionMenu, "QuickCastSelectionMenu", nameof(TORGameKeyContext), InputKey.Q, InputKey.ControllerLLeft, nameof(TORGameKeyContext))); //Registered d-pad left as Quickcast menu button.
             RegisterGameKey(new GameKey(QuickCast, "QuickCast", nameof(TORGameKeyContext), InputKey.MiddleMouseButton, nameof(TORGameKeyContext)));
             RegisterGameKey(new GameKey(CareerAbilityCast, "CareerAbilityCast", nameof(TORGameKeyContext), InputKey.LeftAlt, nameof(TORGameKeyContext)));
         }


### PR DESCRIPTION

TORGameKeyContext.cs: Added controller button for Quick Cast Selection Menu (D-pad left) 

AbilityManagerMissionLogic.cs: Added a reference to Input Manager to check for Game keys instead of direct inputs. It checks for attack keys (default binds are left mouse and right trigger) instead of directly checking for left mouse input.
Removed controller bind of view character to free D-pad left button.